### PR TITLE
Add adminhtml mass action 'Regenerate Url' for product grid

### DIFF
--- a/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
@@ -1,68 +1,47 @@
 <?php
 namespace Iazel\RegenProductUrl\Console\Command;
 
-use Magento\Catalog\Model\Product\Visibility;
+use Iazel\RegenProductUrl\Service\RegenerateProductUrl;
+use Magento\Framework\App\State;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
-use Magento\UrlRewrite\Model\UrlPersistInterface;
-use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
-use Magento\Catalog\Model\ResourceModel\Product\Collection;
-use Magento\Store\Model\Store;
-use Magento\Framework\App\State;
 
 class RegenerateProductUrlCommand extends Command
 {
     /**
-     * @var ProductUrlRewriteGenerator\Proxy
-     */
-    protected $productUrlRewriteGenerator;
-
-    /**
-     * @var UrlPersistInterface\Proxy
-     */
-    protected $urlPersist;
-
-    /**
-     * @var Collection\Proxy
-     */
-    protected $collection;
-
-    /**
      * @var \Magento\Framework\App\State
      */
-    protected $state;
-    
+    private $state;
     /**
      * @var StoreManagerInterface\Proxy
      */
     private $storeManager;
+    /**
+     * @var RegenerateProductUrl
+     */
+    private $regenerateProductUrl;
 
     /**
      * RegenerateProductUrlCommand constructor.
      * @param State $state
-     * @param Collection\Proxy $collection
-     * @param ProductUrlRewriteGenerator\Proxy $productUrlRewriteGenerator
-     * @param UrlPersistInterface\Proxy $urlPersist
      * @param StoreManagerInterface\Proxy $storeManager
+     * @param RegenerateProductUrl $regenerateProductUrl
      */
     public function __construct(
         State $state,
-        Collection\Proxy $collection,
-        ProductUrlRewriteGenerator\Proxy $productUrlRewriteGenerator,
-        UrlPersistInterface\Proxy $urlPersist,
-        StoreManagerInterface\Proxy $storeManager
+        StoreManagerInterface\Proxy $storeManager,
+        RegenerateProductUrl $regenerateProductUrl
     ) {
         $this->state = $state;
-        $this->collection = $collection;
-        $this->productUrlRewriteGenerator = $productUrlRewriteGenerator;
-        $this->urlPersist = $urlPersist;
-        parent::__construct();
         $this->storeManager = $storeManager;
+        $this->regenerateProductUrl = $regenerateProductUrl;
+        parent::__construct();
     }
 
     protected function configure()
@@ -78,7 +57,8 @@ class RegenerateProductUrlCommand extends Command
             ->addArgument(
                 'pids',
                 InputArgument::IS_ARRAY,
-                'Product IDs to regenerate'
+                'Product IDs to regenerate',
+                []
             );
     }
 
@@ -97,53 +77,11 @@ class RegenerateProductUrlCommand extends Command
             $storeId = $this->getStoreIdByCode($storeId, $stores);
         }
 
-        if (!is_numeric($storeId)) {
-            throw new \Exception('Store could not be found. Please enter a store ID or a store code.');
-        } else {
-            $this->storeManager->getStore($storeId);
-        }
-
-        foreach ($stores as $store) {
-            // If store has been given through option, skip other stores
-            if ($storeId != Store::DEFAULT_STORE_ID AND $store->getId() != $storeId) {
-                continue;
-            }
-
-            $this->collection
-                ->addStoreFilter($store->getId())
-                ->setStoreId($store->getId())
-                ->addFieldToFilter('visibility', ['gt' => Visibility::VISIBILITY_NOT_VISIBLE]);
-
-            $pids = $input->getArgument('pids');
-            if (!empty($pids)) {
-                $this->collection->addIdFilter($pids);
-            }
-
-            $this->collection->addAttributeToSelect(['url_path', 'url_key']);
-            $list = $this->collection->load();
-            $regenerated = 0;
-
-            /** @var \Magento\Catalog\Model\Product $product */
-            foreach ($list as $product) {
-                echo 'Regenerating urls for ' . $product->getSku() . ' (' . $product->getId() . ') in store ' . $store->getName() . PHP_EOL;
-                $product->setStoreId($store->getId());
-
-                $this->urlPersist->deleteByData([
-                    UrlRewrite::ENTITY_ID => $product->getId(),
-                    UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
-                    UrlRewrite::REDIRECT_TYPE => 0,
-                    UrlRewrite::STORE_ID => $store->getId()
-                ]);
-
-                $newUrls = $this->productUrlRewriteGenerator->generate($product);
-                try {
-                    $this->urlPersist->replace($newUrls);
-                    $regenerated += count($newUrls);
-                } catch (\Exception $e) {
-                    $output->writeln(sprintf('<error>Duplicated url for store ID %d, product %d (%s) - %s Generated URLs:' . PHP_EOL . '%s</error>' . PHP_EOL, $store->getId(), $product->getId(), $product->getSku(), $e->getMessage(), implode(PHP_EOL, array_keys($newUrls))));
-                }
-            }
-            $output->writeln('Done regenerating. Regenerated ' . $regenerated . ' urls for store ' . $store->getName());
+        try {
+            $this->regenerateProductUrl->setOutput($output);
+            $this->regenerateProductUrl->execute($input->getArgument('pids'), (int) $storeId);
+        } catch (NoSuchEntityException $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
         }
     }
 

--- a/Iazel/RegenProductUrl/Controller/Adminhtml/Action/Product.php
+++ b/Iazel/RegenProductUrl/Controller/Adminhtml/Action/Product.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Iazel\RegenProductUrl\Controller\Adminhtml\Action;
+
+use Exception;
+use Iazel\RegenProductUrl\Service\RegenerateProductUrl;
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Ui\Component\MassAction\Filter;
+
+class Product extends Action
+{
+    /**
+     * @var RegenerateProductUrl
+     */
+    private $regenerateProductUrl;
+    /**
+     * @var Filter
+     */
+    private $filter;
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    public function __construct(
+        CollectionFactory $collectionFactory,
+        Filter $filter,
+        RegenerateProductUrl $regenerateProductUrl,
+        Context $context
+    ) {
+        $this->collectionFactory = $collectionFactory;
+        $this->filter = $filter;
+        $this->regenerateProductUrl = $regenerateProductUrl;
+        parent::__construct($context);
+    }
+
+    /**
+     * Execute action based on request and return result
+     *
+     * Note: Request will be added as operation argument in future
+     *
+     * @return ResultInterface|ResponseInterface
+     * @throws LocalizedException
+     */
+    public function execute()
+    {
+        $productIds = $this->getSelectedProductIds();
+        $storeId = (int) $this->getRequest()->getParam('store', 0);
+        $filters = $this->getRequest()->getParam('filters', []);
+
+        if (isset($filters['store_id'])) {
+            $storeId = (int) $filters['store_id'];
+        }
+
+        try {
+            $this->regenerateProductUrl->execute($productIds, $storeId);
+            $this->messageManager->addSuccessMessage(__(
+                'Successfully regenerated %1 urls for store id %2.',
+                $this->regenerateProductUrl->getRegeneratedCount(),
+                $storeId
+            ));
+        } catch (Exception $e) {
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong while regenerating the product(s) url.'));
+        }
+
+        $resultRedirect = $this->resultRedirectFactory->create();
+        return $resultRedirect->setPath('catalog/product/index');
+    }
+
+    /**
+     * @return array
+     * @throws LocalizedException
+     */
+    private function getSelectedProductIds(): array
+    {
+        return $this->filter->getCollection(
+            $this->collectionFactory->create()
+        )->getAllIds();
+    }
+}

--- a/Iazel/RegenProductUrl/Service/RegenerateProductUrl.php
+++ b/Iazel/RegenProductUrl/Service/RegenerateProductUrl.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Iazel\RegenProductUrl\Service;
+
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
+use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\UrlRewrite\Model\UrlPersistInterface;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RegenerateProductUrl
+{
+    /**
+     * @var OutputInterface|null
+     */
+    private $output;
+    /**
+     * @var Collection\Proxy
+     */
+    private $collection;
+    /**
+     * @var ProductUrlRewriteGenerator\Proxy
+     */
+    private $urlRewriteGenerator;
+    /**
+     * @var UrlPersistInterface\Proxy
+     */
+    private $urlPersist;
+    /**
+     * @var StoreManagerInterface\Proxy
+     */
+    private $storeManager;
+
+    public function __construct(
+        Collection\Proxy $collection,
+        ProductUrlRewriteGenerator\Proxy $urlRewriteGenerator,
+        UrlPersistInterface\Proxy $urlPersist,
+        StoreManagerInterface\Proxy $storeManager
+    ) {
+        $this->collection = $collection;
+        $this->urlRewriteGenerator = $urlRewriteGenerator;
+        $this->urlPersist = $urlPersist;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * @param int[] $productIds
+     * @param int $storeId
+     * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function execute(array $productIds, int $storeId)
+    {
+        $this->storeManager->getStore($storeId);
+
+        $stores = $this->storeManager->getStores(false);
+        foreach ($stores as $store) {
+            // If store has been given through option, skip other stores
+            if ($storeId !== Store::DEFAULT_STORE_ID AND (int) $store->getId() !== $storeId) {
+                continue;
+            }
+
+            $this->collection
+                ->addStoreFilter($store->getId())
+                ->setStoreId($store->getId())
+                ->addFieldToFilter('visibility', ['gt' => Visibility::VISIBILITY_NOT_VISIBLE]);
+
+            if (!empty($productIds)) {
+                $this->collection->addIdFilter($productIds);
+            }
+
+            $this->collection->addAttributeToSelect(['url_path', 'url_key']);
+            $list = $this->collection->load();
+            $regenerated = 0;
+
+            /** @var \Magento\Catalog\Model\Product $product */
+            foreach ($list as $product) {
+                $this->log('Regenerating urls for ' . $product->getSku() . ' (' . $product->getId() . ') in store ' . $store->getName());
+                $product->setStoreId($store->getId());
+
+                $this->urlPersist->deleteByData([
+                    UrlRewrite::ENTITY_ID => $product->getId(),
+                    UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
+                    UrlRewrite::REDIRECT_TYPE => 0,
+                    UrlRewrite::STORE_ID => $store->getId()
+                ]);
+
+                $newUrls = $this->urlRewriteGenerator->generate($product);
+                try {
+                    $this->urlPersist->replace($newUrls);
+                    $regenerated += count($newUrls);
+                } catch (\Exception $e) {
+                    $this->log(sprintf('<error>Duplicated url for store ID %d, product %d (%s) - %s Generated URLs:' . PHP_EOL . '%s</error>' . PHP_EOL, $store->getId(), $product->getId(), $product->getSku(), $e->getMessage(), implode(PHP_EOL, array_keys($newUrls))));
+                }
+            }
+            $this->log('Done regenerating. Regenerated ' . $regenerated . ' urls for store ' . $store->getName());
+        }
+    }
+
+    public function setOutput(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    private function log(string $message)
+    {
+        if ($this->output !== null) {
+            $this->output->writeln($message);
+        }
+    }
+}

--- a/Iazel/RegenProductUrl/Service/RegenerateProductUrl.php
+++ b/Iazel/RegenProductUrl/Service/RegenerateProductUrl.php
@@ -62,11 +62,11 @@ class RegenerateProductUrl
     public function execute(array $productIds, int $storeId)
     {
         $this->storeManager->getStore($storeId);
-
         $this->regeneratedCount = 0;
 
         $stores = $this->storeManager->getStores(false);
         foreach ($stores as $store) {
+            $regeneratedForStore = 0;
             // If store has been given through option, skip other stores
             if ($storeId !== Store::DEFAULT_STORE_ID AND (int) $store->getId() !== $storeId) {
                 continue;
@@ -99,12 +99,13 @@ class RegenerateProductUrl
                 $newUrls = $this->urlRewriteGenerator->generate($product);
                 try {
                     $this->urlPersist->replace($newUrls);
-                    $this->regeneratedCount += count($newUrls);
+                    $regeneratedForStore += count($newUrls);
                 } catch (\Exception $e) {
                     $this->log(sprintf('<error>Duplicated url for store ID %d, product %d (%s) - %s Generated URLs:' . PHP_EOL . '%s</error>' . PHP_EOL, $store->getId(), $product->getId(), $product->getSku(), $e->getMessage(), implode(PHP_EOL, array_keys($newUrls))));
                 }
             }
-            $this->log('Done regenerating. Regenerated ' . $this->regeneratedCount . ' urls for store ' . $store->getName());
+            $this->log('Done regenerating. Regenerated ' . $regeneratedForStore . ' urls for store ' . $store->getName());
+            $this->regeneratedCount += $regeneratedForStore;
         }
     }
 

--- a/Iazel/RegenProductUrl/etc/adminhtml/routes.xml
+++ b/Iazel/RegenProductUrl/etc/adminhtml/routes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="regenerate_urls" frontName="regenerate_url">
+            <module name="Iazel_RegenProductUrl"/>
+        </route>
+    </router>
+</config>

--- a/Iazel/RegenProductUrl/etc/di.xml
+++ b/Iazel/RegenProductUrl/etc/di.xml
@@ -1,10 +1,4 @@
 <?xml version="1.0"?>
-<!--
-/**
- * Copyright © 2016 Magento. All rights reserved.
- * See COPYING.txt for license details.
- */
--->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Framework\Console\CommandList">
         <arguments>

--- a/Iazel/RegenProductUrl/etc/events.xml
+++ b/Iazel/RegenProductUrl/etc/events.xml
@@ -1,10 +1,4 @@
 <?xml version="1.0"?>
-<!--
-/**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
- */
--->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="regenerate_category_url_path">
         <observer name="category_url_path_autogeneration" instance="Magento\CatalogUrlRewrite\Observer\CategoryUrlPathAutogeneratorObserver"/>

--- a/Iazel/RegenProductUrl/i18n/en_US.csv
+++ b/Iazel/RegenProductUrl/i18n/en_US.csv
@@ -1,0 +1,3 @@
+"Successfully regenerated %1 urls for store id %2.","Successfully regenerated %1 urls for store id %2."
+"Something went wrong while regenerating the product(s) url.","Something went wrong while regenerating the product(s) url."
+"Regenerate Url","Regenerate Url"

--- a/Iazel/RegenProductUrl/view/adminhtml/ui_component/product_listing.xml
+++ b/Iazel/RegenProductUrl/view/adminhtml/ui_component/product_listing.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <listingToolbar name="listing_top">
+        <massaction name="listing_massaction"
+                    component="Magento_Ui/js/grid/tree-massactions">
+            <action name="regenerate_url">
+                <settings>
+                    <type>regenerate_url</type>
+                    <label translate="true">Regenerate Url</label>
+                    <url path="regenerate_url/action/product"/>
+                </settings>
+            </action>
+        </massaction>
+    </listingToolbar>
+</listing>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "elgentos/regenerate-catalog-urls",
   "description": "N/A",
   "require": {
-    "php": "~5.6.0|~7.0|~7.1|~7.2",
+    "php": "~7.1|~7.2",
     "magento/framework": ">=100.1",
     "magento/module-catalog-url-rewrite": ">=100.1",
     "magento/magento-composer-installer": "*"


### PR DESCRIPTION
With this feature, store managers are no longer dependent of people with remote access to the server to regenerate some product urls :tada:. 

This also fixes #23, because one could create selections (like id ranges) in product grid and use this mass action.

**Select mass action**
![image](https://user-images.githubusercontent.com/1165302/64431410-a9a26f00-d0ba-11e9-9ec7-06903fb7c6a1.png)

**Notification after regeneration**
![image](https://user-images.githubusercontent.com/1165302/64431446-c048c600-d0ba-11e9-96ae-86c489730e5e.png)

**Questions**
- Does the code conform to your quality standards?
- Should ACL be added to limit access to this action?
