### PR TITLE
Generate correct url from categories belongs other tree category

### DIFF
--- a/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryUrlCommand.php
@@ -90,6 +90,13 @@ class RegenerateCategoryUrlCommand extends Command
                 'Use the specific Store View',
                 Store::DEFAULT_STORE_ID
             )
+            ->addOption(
+                'rootcatid',
+                'r',
+                InputOption::VALUE_OPTIONAL,
+                'Indicate root category id for generate correct URL for categories under other root category that doesn\'t belong to the default category tree.'
+            );
+
         ;
         return parent::configure();
     }
@@ -112,6 +119,19 @@ class RegenerateCategoryUrlCommand extends Command
         $cids = $inp->getArgument('cids');
         if (!empty($cids)) {
             $categories->addAttributeToFilter('entity_id', ['in' => $cids]);
+        }
+
+        /*
+         * When we have more than one category tree and we need the category URLs of that tree to be regenerated,
+         * it is necessary to indicate the root category so that in the url_rewrite table
+         * the entity id points to that of the category of that tree
+         *
+         * example: bin/magento regenerate:category:url -r749 -s29
+         * */
+        if ($inp->hasOption('rootcatid') && !empty($inp->getOption('rootcatid'))) {
+            $rootCatId = $inp->getOption('rootcatid');
+            $out->writeln('TREE CATEGORY FILTER ' . $rootCatId);
+            $categories->addAttributeToFilter('path', ['like' => '%' . $rootCatId . '%']);
         }
 
         $regenerated = 0;

--- a/README.md
+++ b/README.md
@@ -21,14 +21,16 @@ Or download and copy the `Iazel` directory into `app/code/`, enable the module a
 Usage:
  regenerate:product:url [-s|--store="..."] [pids1] ... [pidsN]
  regenerate:category:url [-s]--store="..."] [cids1] ... [cidsN]
+ regenerate:category:url [-r]--rootcatid="..."] [-s]--store="..."] [cids1] ... [cidsN] 
  regenerate:category:path [-s]--store="..."] [cids1] ... [cidsN]
-
+ 
 Arguments:
  pids                  Products to regenerate
  cids                  Categories to regenerate
 
 Options:
  --store (-s)          Use the specific Store View (default: 0)
+ --rootcatid (-s)      Use the specific root category id (required by regenerate url category successful from other tree category)
  --help (-h)           Display this help message
 ```
 


### PR DESCRIPTION
 When we have more than one category tree and we need the category URLs of that tree to be regenerated,it is necessary to indicate the root category so that in the url_rewrite table
 the entity id points to that of the category of that tree