### PR TITLE
fix: Use CommandListInterface

### DIFF
--- a/Iazel/RegenProductUrl/etc/di.xml
+++ b/Iazel/RegenProductUrl/etc/di.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <type name="Magento\Framework\Console\CommandList">
+    <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="product_url_regeneration_command" xsi:type="object">Iazel\RegenProductUrl\Console\Command\RegenerateProductUrlCommand</item>


### PR DESCRIPTION
Configuring commands in the Magento Console Command List should be done on its interface. Otherwise the commands won't show up in generated production code.